### PR TITLE
docs: Fix tutorial link to point to interactive viewer

### DIFF
--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,12 +1,51 @@
-=========
-Tutorials
-=========
+======================
+Interactive Tutorial
+======================
 
+To truly master ``ChemInformant``, we highly recommend using the interactive user manual. It's a live Jupyter Notebook environment hosted on Google Colab, designed to bridge the gap between theory and practice.
 
+**Click the badge below to launch the tutorial now:**
 
+.. image:: https://colab.research.google.com/assets/colab-badge.svg
+   :target: https://colab.research.google.com/github/HzaCode/ChemInformant/blob/main/examples/ChemInformant_User_Manual_v1.0.ipynb
+   :alt: Open in Colab
 
-For the best learning experience, we highly recommend downloading the accompanying Jupyter Notebook for this page. It contains all the runnable code examples, allowing you to get hands-on, modify parameters, and observe the results to gain a deeper understanding of how to apply ChemInformant in practical workflows.
+--------------------
+**Quick Start Guide**
+--------------------
 
-**Download the interactive tutorial:**
+To ensure the best experience and to save your progress, please follow these steps:
 
-`ChemInformant User Manual (ChemInformant_User_Manual_v1.0.ipynb) <https://raw.githubusercontent.com/HzaCode/ChemInformant/main/examples/ChemInformant_User_Manual_v1.0.ipynb>`__
+**1. Save a Personal Copy**
+   Once the notebook opens in Colab, immediately go to the menu and click **``File -> Save a copy in Drive``**. This creates a personal, editable copy in your own Google Drive.
+
+**2. Execute Cells in Order**
+   The tutorial is designed to be followed sequentially. Run each code cell from top to bottom by clicking the "▶️" play button or using the shortcut ``Shift + Enter``.
+
+**3. Interact and Experiment**
+   Don't hesitate to modify the code! Try different compound names, request other properties, and observe how the output changes. This is the best way to learn how to apply ``ChemInformant`` to your own work.
+
+--------------------------
+**What You Will Learn**
+--------------------------
+
+This hands-on manual covers the entire workflow, from installation to advanced data analysis. Specifically, you will learn to:
+
+*   **Setup the Environment**:
+    Install ``ChemInformant`` with all necessary extras and import required libraries in a single step.
+
+*   **Master Core Functions**:
+    Use the powerful ``get_properties`` function to retrieve data for multiple compounds and properties at once, directly into a Pandas DataFrame.
+
+*   **Leverage the Convenience API**:
+    Perform quick lookups for single properties like molecular weight, SMILES, or IUPAC names using simple, intuitive functions (e.g., ``get_weight()``, ``get_cas()``).
+
+*   **Perform Batch Data Analysis**:
+    Retrieve, clean, and analyze data for a list of common drugs, then visualize physicochemical properties like molecular weight distribution and lipophilicity.
+
+*   **Apply Advanced Use Cases**:
+    - **Drug-Likeness Assessment**: Implement and visualize Lipinski's Rule of Five to assess compounds.
+    - **Machine Learning Clustering**: Use K-Means to cluster drugs based on their properties and visualize the results.
+
+*   **Export Your Results**:
+    Save your analysis into common formats like CSV, multi-sheet Excel files, and SMILES files for use in other cheminformatics software.


### PR DESCRIPTION
This PR addresses the issue raised in #18 regarding the incorrect tutorial link.

The old link on the tutorials page directed users to a raw Jupyter Notebook file instead of a properly rendered, interactive environment. This created a poor user experience.

### Key Changes:

- The direct link to the `.ipynb` file in `tutorials.rst` has been replaced with a Google Colab badge.
- This new link directs users to a live, zero-setup, interactive session where they can run all the code examples directly in their browser.
- The accompanying text has also been updated to guide users on how to use the Colab environment effectively, including instructions on how to save a personal copy.

This change ensures that users have a smooth and productive learning experience, as originally intended.

Fixes #18